### PR TITLE
feat: allow some actual values to be omitted

### DIFF
--- a/src/grammar.peg
+++ b/src/grammar.peg
@@ -42,7 +42,7 @@ STATS             := h=STAT '-' a=STAT '-' b=STAT '-' c=STAT '-' d=STAT '-' s=ST
 STAT              := ACTUAL_AND_EFFORT | ACTUAL
 ACTUAL_AND_EFFORT := actual=ACTUAL_VALUE '\(' effort=EFFORT_VALUE '\)'
 ACTUAL            := actual=ACTUAL_VALUE
-ACTUAL_VALUE      := '[1-9][0-9]*'
+ACTUAL_VALUE      := '[1-9][0-9]*' | 'x'
 EFFORT_VALUE      := '[1-9][0-9]*'
 INDIVIDUALS       := '[HABCDS0-9, ]+' // TODO: ちゃんとパースする
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -104,12 +104,17 @@ export const parse = (pokesolText: string): PokesolTextParseReult => {
       result.ast.line5.body.stats.s.kind === ASTKinds.ACTUAL_AND_EFFORT
         ? Number(result.ast.line5.body.stats.s.effort)
         : 0;
-    actualValue.hp = Number(result.ast.line5.body.stats.h.actual);
-    actualValue.attack = Number(result.ast.line5.body.stats.a.actual);
-    actualValue.defense = Number(result.ast.line5.body.stats.b.actual);
-    actualValue.specialAttack = Number(result.ast.line5.body.stats.c.actual);
-    actualValue.specialDefense = Number(result.ast.line5.body.stats.d.actual);
-    actualValue.speed = Number(result.ast.line5.body.stats.s.actual);
+
+    const stringToValue = (input: string): number | null => {
+      const num = Number(input);
+      return isNaN(num) ? null : num;
+    }
+    actualValue.hp = stringToValue(result.ast.line5.body.stats.h.actual);
+    actualValue.attack = stringToValue(result.ast.line5.body.stats.a.actual);
+    actualValue.defense = stringToValue(result.ast.line5.body.stats.b.actual);
+    actualValue.specialAttack = stringToValue(result.ast.line5.body.stats.c.actual);
+    actualValue.specialDefense = stringToValue(result.ast.line5.body.stats.d.actual);
+    actualValue.speed = stringToValue(result.ast.line5.body.stats.s.actual);
 
     if (result.ast.line5.body.kind === ASTKinds.STATS_AND_IV_LINE) {
       result.ast.line5.body.individuals.split(",").forEach((iv) => {

--- a/src/parser.ts
+++ b/src/parser.ts
@@ -28,7 +28,7 @@
 * STAT              := ACTUAL_AND_EFFORT | ACTUAL
 * ACTUAL_AND_EFFORT := actual=ACTUAL_VALUE '\(' effort=EFFORT_VALUE '\)'
 * ACTUAL            := actual=ACTUAL_VALUE
-* ACTUAL_VALUE      := '[1-9][0-9]*'
+* ACTUAL_VALUE      := '[1-9][0-9]*' | 'x'
 * EFFORT_VALUE      := '[1-9][0-9]*'
 * INDIVIDUALS       := '[HABCDS0-9, ]+' // TODO: ちゃんとパースする
 * // 6 行目
@@ -71,7 +71,8 @@ export enum ASTKinds {
     STAT_2 = "STAT_2",
     ACTUAL_AND_EFFORT = "ACTUAL_AND_EFFORT",
     ACTUAL = "ACTUAL",
-    ACTUAL_VALUE = "ACTUAL_VALUE",
+    ACTUAL_VALUE_1 = "ACTUAL_VALUE_1",
+    ACTUAL_VALUE_2 = "ACTUAL_VALUE_2",
     EFFORT_VALUE = "EFFORT_VALUE",
     INDIVIDUALS = "INDIVIDUALS",
     MOVES_LINE_1 = "MOVES_LINE_1",
@@ -164,7 +165,9 @@ export interface ACTUAL {
     kind: ASTKinds.ACTUAL;
     actual: ACTUAL_VALUE;
 }
-export type ACTUAL_VALUE = string;
+export type ACTUAL_VALUE = ACTUAL_VALUE_1 | ACTUAL_VALUE_2;
+export type ACTUAL_VALUE_1 = string;
+export type ACTUAL_VALUE_2 = string;
 export type EFFORT_VALUE = string;
 export type INDIVIDUALS = string;
 export type MOVES_LINE = MOVES_LINE_1 | MOVES_LINE_2 | MOVES_LINE_3 | MOVES_LINE_4;
@@ -490,7 +493,16 @@ export class Parser {
             });
     }
     public matchACTUAL_VALUE($$dpth: number, $$cr?: ErrorTracker): Nullable<ACTUAL_VALUE> {
+        return this.choice<ACTUAL_VALUE>([
+            () => this.matchACTUAL_VALUE_1($$dpth + 1, $$cr),
+            () => this.matchACTUAL_VALUE_2($$dpth + 1, $$cr),
+        ]);
+    }
+    public matchACTUAL_VALUE_1($$dpth: number, $$cr?: ErrorTracker): Nullable<ACTUAL_VALUE_1> {
         return this.regexAccept(String.raw`(?:[1-9][0-9]*)`, "", $$dpth + 1, $$cr);
+    }
+    public matchACTUAL_VALUE_2($$dpth: number, $$cr?: ErrorTracker): Nullable<ACTUAL_VALUE_2> {
+        return this.regexAccept(String.raw`(?:x)`, "", $$dpth + 1, $$cr);
     }
     public matchEFFORT_VALUE($$dpth: number, $$cr?: ErrorTracker): Nullable<EFFORT_VALUE> {
         return this.regexAccept(String.raw`(?:[1-9][0-9]*)`, "", $$dpth + 1, $$cr);

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -419,4 +419,40 @@ describe("parse", () => {
 `;
     expect(parse(pokesolText)).toEqual(expected);
   });
+
+  test("without some actual values", () => {
+    const pokesolText = `カイリュー @ あおぞらプレート
+テラスタイプ: ステラ
+特性: マルチスケイル
+性格: さみしがり
+166-204(252)-132(252)-x-105-101(4) *D0
+じしん / りゅうのまい / テラバースト / けたぐり`;
+    expect(parse(pokesolText)).toMatchObject({...expected,
+      ivs: {
+        hp: 31,
+        attack: 31,
+        defense: 31,
+        specialAttack: 31,
+        specialDefense: 0,
+        speed: 31,
+      },
+      actualValue: {
+        hp: 166,
+        attack: 204,
+        defense: 132,
+        specialAttack: null,
+        specialDefense: 105,
+        speed: 101,
+      },
+      evs: {
+        hp: 0,
+        attack: 252,
+        defense: 252,
+        specialAttack: 0,
+        specialDefense: 0,
+        speed: 4,
+      },
+    });
+  });
+
 });


### PR DESCRIPTION
For example, Special Attack of an attacker using physical attacks would often be omitted, `166-204(252)-132(252)-x-105-101(4)`. Introduce a feature to parse texts whose status values are omitted.

## Changes
The syntax has been changed so that status values that are not explicitly specified can be represented by `“x”`.

## Testing
Local tests using `$ npm run test` passed with my changes.

## Concerns
* I am not very familiar with PEG, so please let me know if there are any problems with the changes.
* Based on information from several sources, I used `“x”` to denote omitted values. Please let me know if `“x”` is not common.

I am a fan of Pokesol. Thank you for developing a great library.