### PR TITLE
support champions format: optional teratype, pre-mega ability, and rename nature label

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,40 +10,40 @@ pnpm add @pokesol/pokesol-text-parser-ts
 import { parse } from "@pokesol/pokesol-text-parser-ts"
 
 const pokesolText = `
-カイリュー @ あおぞらプレート
-テラスタイプ: ステラ
-特性: マルチスケイル
-能力補正: さみしがり
-166-204(32)-132(32)-105-105-101(2)
-じしん / りゅうのまい / テラバースト / けたぐり
+メガガブリアス @ ガブリアスナイト
+テラスタイプ:
+特性: すなのちから(さめはだ)
+能力補正: ようき
+193(10)-200(10)-145(10)-135(10)-125(10)-140(16)
+スケイルショット / だいちのちから / がんせきふうじ / ステルスロック
 `
 
 console.dir(parse(pokesolText), { depth: null })
 
 {
-  pokemonName: 'カイリュー',
-  itemName: 'あおぞらプレート',
-  abilityName: 'マルチスケイル',
-  preMegaAbilityName: null,
-  terastalName: 'ステラ',
-  natureName: 'さみしがり',
+  pokemonName: 'メガガブリアス',
+  itemName: 'ガブリアスナイト',
+  abilityName: 'すなのちから',
+  preMegaAbilityName: 'さめはだ',
+  terastalName: null,
+  natureName: 'ようき',
   evs: {
-    hp: 0,
-    attack: 32,
-    defense: 32,
-    specialAttack: 0,
-    specialDefense: 0,
-    speed: 2
+    hp: 10,
+    attack: 10,
+    defense: 10,
+    specialAttack: 10,
+    specialDefense: 10,
+    speed: 16
   },
   actualValue: {
-    hp: 166,
-    attack: 204,
-    defense: 132,
-    specialAttack: 105,
-    specialDefense: 105,
-    speed: 101
+    hp: 193,
+    attack: 200,
+    defense: 145,
+    specialAttack: 135,
+    specialDefense: 125,
+    speed: 140
   },
-  moveNames: [ 'じしん', 'りゅうのまい', 'テラバースト', 'けたぐり' ]
+  moveNames: [ 'スケイルショット', 'だいちのちから', 'がんせきふうじ', 'ステルスロック' ]
 }
 ```
 

--- a/README.md
+++ b/README.md
@@ -13,8 +13,8 @@ const pokesolText = `
 カイリュー @ あおぞらプレート
 テラスタイプ: ステラ
 特性: マルチスケイル
-性格: さみしがり
-166-204(252)-132(252)-105-105-101(4) *C0,D0
+能力補正: さみしがり
+166-204(32)-132(32)-105-105-101(2)
 じしん / りゅうのまい / テラバースト / けたぐり
 `
 
@@ -24,23 +24,16 @@ console.dir(parse(pokesolText), { depth: null })
   pokemonName: 'カイリュー',
   itemName: 'あおぞらプレート',
   abilityName: 'マルチスケイル',
+  preMegaAbilityName: null,
   terastalName: 'ステラ',
   natureName: 'さみしがり',
-  ivs: {
-    hp: 31,
-    attack: 31,
-    defense: 31,
-    specialAttack: 0,
-    specialDefense: 0,
-    speed: 31
-  },
   evs: {
     hp: 0,
-    attack: 252,
-    defense: 252,
+    attack: 32,
+    defense: 32,
     specialAttack: 0,
     specialDefense: 0,
-    speed: 4
+    speed: 2
   },
   actualValue: {
     hp: 166,

--- a/src/grammar.peg
+++ b/src/grammar.peg
@@ -1,9 +1,9 @@
 POKESOL_TEXT :=
   line1={ POKEMON_AND_ITEM_LINE | POKEMON_LINE } '\n+'
-  line2=TERATYPE_LINE '\n+'
+  line2={ body=TERATYPE_LINE '\n+' }?
   line3=ABILITY_LINE '\n+'
   line4=NATURE_LINE
-  line5={ '\n+' body={ STATS_AND_IV_LINE | STATS_LINE } }?
+  line5={ '\n+' body=STATS_LINE }?
   line6={ '\n+' body=MOVES_LINE }?
 
 
@@ -17,25 +17,24 @@ ITEM_VALUE            := '[ぁ-んァ-ヶー]+'
 
 // 2 行目
 
-TERATYPE_LINE  := 'テラスタイプ' _ ':' _ teratype=TERATYPE_VALUE?
+TERATYPE_LINE  := 'テラスタイプ' _ ':' _ teratype=TERATYPE_VALUE
 TERATYPE_VALUE := '[ぁ-んァ-ヶー]*'
 
 
 // 3 行目
 
-ABILITY_LINE  := '特性' _ ':' _ ability=ABILITY_VALUE?
+ABILITY_LINE  := '特性' _ ':' _ ability=ABILITY_VALUE? preMega={ '\(' body=ABILITY_VALUE '\)' }?
 ABILITY_VALUE := '[ぁ-んァ-ヶー]+'
 
 
 // 4 行目
 
-NATURE_LINE  := '性格' _ ':' _ nature=NATURE_VALUE?
+NATURE_LINE  := '能力補正' _ ':' _ nature=NATURE_VALUE?
 NATURE_VALUE := '[ぁ-ん]+'
 
 
 // 5 行目
 
-STATS_AND_IV_LINE := stats=STATS _ '\*' _ individuals=INDIVIDUALS
 STATS_LINE        := stats=STATS
 
 STATS             := h=STAT '-' a=STAT '-' b=STAT '-' c=STAT '-' d=STAT '-' s=STAT
@@ -44,7 +43,6 @@ ACTUAL_AND_EFFORT := actual=ACTUAL_VALUE '\(' effort=EFFORT_VALUE '\)'
 ACTUAL            := actual=ACTUAL_VALUE
 ACTUAL_VALUE      := '[1-9][0-9]*'
 EFFORT_VALUE      := '[1-9][0-9]*'
-INDIVIDUALS       := '[HABCDS0-9, ]+' // TODO: ちゃんとパースする
 
 
 // 6 行目

--- a/src/grammar.peg
+++ b/src/grammar.peg
@@ -23,7 +23,7 @@ TERATYPE_VALUE := '[ぁ-んァ-ヶー]*'
 
 // 3 行目
 
-ABILITY_LINE  := '特性' _ ':' _ ability=ABILITY_VALUE? preMega={ '\(' body=ABILITY_VALUE '\)' }?
+ABILITY_LINE  := '特性' _ ':' _ ability=ABILITY_VALUE? _ preMega={ '\(' body=ABILITY_VALUE '\)' }?
 ABILITY_VALUE := '[ぁ-んァ-ヶー]+'
 
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -13,16 +13,9 @@ export type PokesolTextParseReult = {
   pokemonName: string | null;
   itemName: string | null;
   abilityName: string | null;
+  preMegaAbilityName: string | null;
   terastalName: string | null;
   natureName: string | null;
-  ivs: {
-    hp: number;
-    attack: number;
-    defense: number;
-    specialAttack: number;
-    specialDefense: number;
-    speed: number;
-  };
   evs: {
     hp: number;
     attack: number;
@@ -50,8 +43,9 @@ export const parse = (pokesolText: string): PokesolTextParseReult => {
       ? result.ast.line1.item
       : null;
 
-  const terastalName = result.ast.line2.teratype || null;
+  const terastalName = result.ast.line2?.body.teratype || null;
   const abilityName = result.ast.line3.ability || null;
+  const preMegaAbilityName = result.ast.line3.preMega?.body || null;
   const natureName = result.ast.line4.nature || null;
 
   const evs = {
@@ -69,14 +63,6 @@ export const parse = (pokesolText: string): PokesolTextParseReult => {
     specialAttack: null,
     specialDefense: null,
     speed: null,
-  };
-  const ivs = {
-    hp: 31,
-    attack: 31,
-    defense: 31,
-    specialAttack: 31,
-    specialDefense: 31,
-    speed: 31,
   };
 
   if (result.ast.line5 !== null) {
@@ -110,35 +96,6 @@ export const parse = (pokesolText: string): PokesolTextParseReult => {
     actualValue.specialAttack = Number(result.ast.line5.body.stats.c.actual);
     actualValue.specialDefense = Number(result.ast.line5.body.stats.d.actual);
     actualValue.speed = Number(result.ast.line5.body.stats.s.actual);
-
-    if (result.ast.line5.body.kind === ASTKinds.STATS_AND_IV_LINE) {
-      result.ast.line5.body.individuals.split(",").forEach((iv) => {
-        const ivStatus = iv.match(/[HABCDS]/);
-        const ivValue = iv.match(/\d+/);
-        if (ivStatus !== null && ivValue !== null) {
-          switch (ivStatus[0]) {
-            case "H":
-              ivs.hp = Number(ivValue[0]);
-              break;
-            case "A":
-              ivs.attack = Number(ivValue[0]);
-              break;
-            case "B":
-              ivs.defense = Number(ivValue[0]);
-              break;
-            case "C":
-              ivs.specialAttack = Number(ivValue[0]);
-              break;
-            case "D":
-              ivs.specialDefense = Number(ivValue[0]);
-              break;
-            case "S":
-              ivs.speed = Number(ivValue[0]);
-              break;
-          }
-        }
-      });
-    }
   }
 
   const moveNames = [];
@@ -164,9 +121,9 @@ export const parse = (pokesolText: string): PokesolTextParseReult => {
     pokemonName,
     itemName,
     abilityName,
+    preMegaAbilityName,
     terastalName,
     natureName,
-    ivs,
     evs,
     actualValue,
     moveNames,

--- a/src/parser.ts
+++ b/src/parser.ts
@@ -16,7 +16,7 @@
 * TERATYPE_LINE  := 'テラスタイプ' _ ':' _ teratype=TERATYPE_VALUE
 * TERATYPE_VALUE := '[ぁ-んァ-ヶー]*'
 * // 3 行目
-* ABILITY_LINE  := '特性' _ ':' _ ability=ABILITY_VALUE? preMega={ '\(' body=ABILITY_VALUE '\)' }?
+* ABILITY_LINE  := '特性' _ ':' _ ability=ABILITY_VALUE? _ preMega={ '\(' body=ABILITY_VALUE '\)' }?
 * ABILITY_VALUE := '[ぁ-んァ-ヶー]+'
 * // 4 行目
 * NATURE_LINE  := '能力補正' _ ':' _ nature=NATURE_VALUE?
@@ -357,6 +357,7 @@ export class Parser {
                     && this.regexAccept(String.raw`(?::)`, "", $$dpth + 1, $$cr) !== null
                     && this.match_($$dpth + 1, $$cr) !== null
                     && (($scope$ability = this.matchABILITY_VALUE($$dpth + 1, $$cr)) || true)
+                    && this.match_($$dpth + 1, $$cr) !== null
                     && (($scope$preMega = this.matchABILITY_LINE_$0($$dpth + 1, $$cr)) || true)
                 ) {
                     $$res = {kind: ASTKinds.ABILITY_LINE, ability: $scope$ability, preMega: $scope$preMega};

--- a/src/parser.ts
+++ b/src/parser.ts
@@ -2,10 +2,10 @@
 * INPUT GRAMMAR:
 * POKESOL_TEXT :=
 *   line1={ POKEMON_AND_ITEM_LINE | POKEMON_LINE } '\n+'
-*   line2=TERATYPE_LINE '\n+'
+*   line2={ body=TERATYPE_LINE '\n+' }?
 *   line3=ABILITY_LINE '\n+'
 *   line4=NATURE_LINE
-*   line5={ '\n+' body={ STATS_AND_IV_LINE | STATS_LINE } }?
+*   line5={ '\n+' body=STATS_LINE }?
 *   line6={ '\n+' body=MOVES_LINE }?
 * // 1 行目
 * POKEMON_AND_ITEM_LINE := pokemon=POKEMON_VALUE _ '@' _ item=ITEM_VALUE
@@ -13,16 +13,15 @@
 * POKEMON_VALUE         := '[0-9０-９a-zA-ZＡ-Ｚぁ-んァ-ヶー一-龠・()♂♀%]+'
 * ITEM_VALUE            := '[ぁ-んァ-ヶー]+'
 * // 2 行目
-* TERATYPE_LINE  := 'テラスタイプ' _ ':' _ teratype=TERATYPE_VALUE?
+* TERATYPE_LINE  := 'テラスタイプ' _ ':' _ teratype=TERATYPE_VALUE
 * TERATYPE_VALUE := '[ぁ-んァ-ヶー]*'
 * // 3 行目
-* ABILITY_LINE  := '特性' _ ':' _ ability=ABILITY_VALUE?
+* ABILITY_LINE  := '特性' _ ':' _ ability=ABILITY_VALUE? preMega={ '\(' body=ABILITY_VALUE '\)' }?
 * ABILITY_VALUE := '[ぁ-んァ-ヶー]+'
 * // 4 行目
-* NATURE_LINE  := '性格' _ ':' _ nature=NATURE_VALUE?
+* NATURE_LINE  := '能力補正' _ ':' _ nature=NATURE_VALUE?
 * NATURE_VALUE := '[ぁ-ん]+'
 * // 5 行目
-* STATS_AND_IV_LINE := stats=STATS _ '\*' _ individuals=INDIVIDUALS
 * STATS_LINE        := stats=STATS
 * STATS             := h=STAT '-' a=STAT '-' b=STAT '-' c=STAT '-' d=STAT '-' s=STAT
 * STAT              := ACTUAL_AND_EFFORT | ACTUAL
@@ -30,7 +29,6 @@
 * ACTUAL            := actual=ACTUAL_VALUE
 * ACTUAL_VALUE      := '[1-9][0-9]*'
 * EFFORT_VALUE      := '[1-9][0-9]*'
-* INDIVIDUALS       := '[HABCDS0-9, ]+' // TODO: ちゃんとパースする
 * // 6 行目
 * MOVES_LINE  := MOVES_FOUR | MOVES_THREE | MOVES_TWO | MOVES_ONE
 * MOVES_FOUR  := move1=MOVE_VALUE _ '/' _ move2=MOVE_VALUE _ '/' _ move3=MOVE_VALUE _ '/' _ move4=MOVE_VALUE
@@ -51,9 +49,8 @@ export enum ASTKinds {
     POKESOL_TEXT_$0_1 = "POKESOL_TEXT_$0_1",
     POKESOL_TEXT_$0_2 = "POKESOL_TEXT_$0_2",
     POKESOL_TEXT_$1 = "POKESOL_TEXT_$1",
-    POKESOL_TEXT_$1_$0_1 = "POKESOL_TEXT_$1_$0_1",
-    POKESOL_TEXT_$1_$0_2 = "POKESOL_TEXT_$1_$0_2",
     POKESOL_TEXT_$2 = "POKESOL_TEXT_$2",
+    POKESOL_TEXT_$3 = "POKESOL_TEXT_$3",
     POKEMON_AND_ITEM_LINE = "POKEMON_AND_ITEM_LINE",
     POKEMON_LINE = "POKEMON_LINE",
     POKEMON_VALUE = "POKEMON_VALUE",
@@ -61,10 +58,10 @@ export enum ASTKinds {
     TERATYPE_LINE = "TERATYPE_LINE",
     TERATYPE_VALUE = "TERATYPE_VALUE",
     ABILITY_LINE = "ABILITY_LINE",
+    ABILITY_LINE_$0 = "ABILITY_LINE_$0",
     ABILITY_VALUE = "ABILITY_VALUE",
     NATURE_LINE = "NATURE_LINE",
     NATURE_VALUE = "NATURE_VALUE",
-    STATS_AND_IV_LINE = "STATS_AND_IV_LINE",
     STATS_LINE = "STATS_LINE",
     STATS = "STATS",
     STAT_1 = "STAT_1",
@@ -73,7 +70,6 @@ export enum ASTKinds {
     ACTUAL = "ACTUAL",
     ACTUAL_VALUE = "ACTUAL_VALUE",
     EFFORT_VALUE = "EFFORT_VALUE",
-    INDIVIDUALS = "INDIVIDUALS",
     MOVES_LINE_1 = "MOVES_LINE_1",
     MOVES_LINE_2 = "MOVES_LINE_2",
     MOVES_LINE_3 = "MOVES_LINE_3",
@@ -88,24 +84,25 @@ export enum ASTKinds {
 export interface POKESOL_TEXT {
     kind: ASTKinds.POKESOL_TEXT;
     line1: POKESOL_TEXT_$0;
-    line2: TERATYPE_LINE;
+    line2: Nullable<POKESOL_TEXT_$1>;
     line3: ABILITY_LINE;
     line4: NATURE_LINE;
-    line5: Nullable<POKESOL_TEXT_$1>;
-    line6: Nullable<POKESOL_TEXT_$2>;
+    line5: Nullable<POKESOL_TEXT_$2>;
+    line6: Nullable<POKESOL_TEXT_$3>;
 }
 export type POKESOL_TEXT_$0 = POKESOL_TEXT_$0_1 | POKESOL_TEXT_$0_2;
 export type POKESOL_TEXT_$0_1 = POKEMON_AND_ITEM_LINE;
 export type POKESOL_TEXT_$0_2 = POKEMON_LINE;
 export interface POKESOL_TEXT_$1 {
     kind: ASTKinds.POKESOL_TEXT_$1;
-    body: POKESOL_TEXT_$1_$0;
+    body: TERATYPE_LINE;
 }
-export type POKESOL_TEXT_$1_$0 = POKESOL_TEXT_$1_$0_1 | POKESOL_TEXT_$1_$0_2;
-export type POKESOL_TEXT_$1_$0_1 = STATS_AND_IV_LINE;
-export type POKESOL_TEXT_$1_$0_2 = STATS_LINE;
 export interface POKESOL_TEXT_$2 {
     kind: ASTKinds.POKESOL_TEXT_$2;
+    body: STATS_LINE;
+}
+export interface POKESOL_TEXT_$3 {
+    kind: ASTKinds.POKESOL_TEXT_$3;
     body: MOVES_LINE;
 }
 export interface POKEMON_AND_ITEM_LINE {
@@ -121,12 +118,17 @@ export type POKEMON_VALUE = string;
 export type ITEM_VALUE = string;
 export interface TERATYPE_LINE {
     kind: ASTKinds.TERATYPE_LINE;
-    teratype: Nullable<TERATYPE_VALUE>;
+    teratype: TERATYPE_VALUE;
 }
 export type TERATYPE_VALUE = string;
 export interface ABILITY_LINE {
     kind: ASTKinds.ABILITY_LINE;
     ability: Nullable<ABILITY_VALUE>;
+    preMega: Nullable<ABILITY_LINE_$0>;
+}
+export interface ABILITY_LINE_$0 {
+    kind: ASTKinds.ABILITY_LINE_$0;
+    body: ABILITY_VALUE;
 }
 export type ABILITY_VALUE = string;
 export interface NATURE_LINE {
@@ -134,11 +136,6 @@ export interface NATURE_LINE {
     nature: Nullable<NATURE_VALUE>;
 }
 export type NATURE_VALUE = string;
-export interface STATS_AND_IV_LINE {
-    kind: ASTKinds.STATS_AND_IV_LINE;
-    stats: STATS;
-    individuals: INDIVIDUALS;
-}
 export interface STATS_LINE {
     kind: ASTKinds.STATS_LINE;
     stats: STATS;
@@ -166,7 +163,6 @@ export interface ACTUAL {
 }
 export type ACTUAL_VALUE = string;
 export type EFFORT_VALUE = string;
-export type INDIVIDUALS = string;
 export type MOVES_LINE = MOVES_LINE_1 | MOVES_LINE_2 | MOVES_LINE_3 | MOVES_LINE_4;
 export type MOVES_LINE_1 = MOVES_FOUR;
 export type MOVES_LINE_2 = MOVES_THREE;
@@ -205,7 +201,7 @@ export class Parser {
         this.pos = {overallPos: 0, line: 1, offset: 0};
         this.input = input;
     }
-    public reset(pos: PosInfo): void {
+    public reset(pos: PosInfo) {
         this.pos = pos;
     }
     public finished(): boolean {
@@ -217,22 +213,21 @@ export class Parser {
         return this.run<POKESOL_TEXT>($$dpth,
             () => {
                 let $scope$line1: Nullable<POKESOL_TEXT_$0>;
-                let $scope$line2: Nullable<TERATYPE_LINE>;
+                let $scope$line2: Nullable<Nullable<POKESOL_TEXT_$1>>;
                 let $scope$line3: Nullable<ABILITY_LINE>;
                 let $scope$line4: Nullable<NATURE_LINE>;
-                let $scope$line5: Nullable<Nullable<POKESOL_TEXT_$1>>;
-                let $scope$line6: Nullable<Nullable<POKESOL_TEXT_$2>>;
+                let $scope$line5: Nullable<Nullable<POKESOL_TEXT_$2>>;
+                let $scope$line6: Nullable<Nullable<POKESOL_TEXT_$3>>;
                 let $$res: Nullable<POKESOL_TEXT> = null;
                 if (true
                     && ($scope$line1 = this.matchPOKESOL_TEXT_$0($$dpth + 1, $$cr)) !== null
                     && this.regexAccept(String.raw`(?:\n+)`, "", $$dpth + 1, $$cr) !== null
-                    && ($scope$line2 = this.matchTERATYPE_LINE($$dpth + 1, $$cr)) !== null
-                    && this.regexAccept(String.raw`(?:\n+)`, "", $$dpth + 1, $$cr) !== null
+                    && (($scope$line2 = this.matchPOKESOL_TEXT_$1($$dpth + 1, $$cr)) || true)
                     && ($scope$line3 = this.matchABILITY_LINE($$dpth + 1, $$cr)) !== null
                     && this.regexAccept(String.raw`(?:\n+)`, "", $$dpth + 1, $$cr) !== null
                     && ($scope$line4 = this.matchNATURE_LINE($$dpth + 1, $$cr)) !== null
-                    && (($scope$line5 = this.matchPOKESOL_TEXT_$1($$dpth + 1, $$cr)) || true)
-                    && (($scope$line6 = this.matchPOKESOL_TEXT_$2($$dpth + 1, $$cr)) || true)
+                    && (($scope$line5 = this.matchPOKESOL_TEXT_$2($$dpth + 1, $$cr)) || true)
+                    && (($scope$line6 = this.matchPOKESOL_TEXT_$3($$dpth + 1, $$cr)) || true)
                 ) {
                     $$res = {kind: ASTKinds.POKESOL_TEXT, line1: $scope$line1, line2: $scope$line2, line3: $scope$line3, line4: $scope$line4, line5: $scope$line5, line6: $scope$line6};
                 }
@@ -254,39 +249,41 @@ export class Parser {
     public matchPOKESOL_TEXT_$1($$dpth: number, $$cr?: ErrorTracker): Nullable<POKESOL_TEXT_$1> {
         return this.run<POKESOL_TEXT_$1>($$dpth,
             () => {
-                let $scope$body: Nullable<POKESOL_TEXT_$1_$0>;
+                let $scope$body: Nullable<TERATYPE_LINE>;
                 let $$res: Nullable<POKESOL_TEXT_$1> = null;
                 if (true
+                    && ($scope$body = this.matchTERATYPE_LINE($$dpth + 1, $$cr)) !== null
                     && this.regexAccept(String.raw`(?:\n+)`, "", $$dpth + 1, $$cr) !== null
-                    && ($scope$body = this.matchPOKESOL_TEXT_$1_$0($$dpth + 1, $$cr)) !== null
                 ) {
                     $$res = {kind: ASTKinds.POKESOL_TEXT_$1, body: $scope$body};
                 }
                 return $$res;
             });
     }
-    public matchPOKESOL_TEXT_$1_$0($$dpth: number, $$cr?: ErrorTracker): Nullable<POKESOL_TEXT_$1_$0> {
-        return this.choice<POKESOL_TEXT_$1_$0>([
-            () => this.matchPOKESOL_TEXT_$1_$0_1($$dpth + 1, $$cr),
-            () => this.matchPOKESOL_TEXT_$1_$0_2($$dpth + 1, $$cr),
-        ]);
-    }
-    public matchPOKESOL_TEXT_$1_$0_1($$dpth: number, $$cr?: ErrorTracker): Nullable<POKESOL_TEXT_$1_$0_1> {
-        return this.matchSTATS_AND_IV_LINE($$dpth + 1, $$cr);
-    }
-    public matchPOKESOL_TEXT_$1_$0_2($$dpth: number, $$cr?: ErrorTracker): Nullable<POKESOL_TEXT_$1_$0_2> {
-        return this.matchSTATS_LINE($$dpth + 1, $$cr);
-    }
     public matchPOKESOL_TEXT_$2($$dpth: number, $$cr?: ErrorTracker): Nullable<POKESOL_TEXT_$2> {
         return this.run<POKESOL_TEXT_$2>($$dpth,
             () => {
-                let $scope$body: Nullable<MOVES_LINE>;
+                let $scope$body: Nullable<STATS_LINE>;
                 let $$res: Nullable<POKESOL_TEXT_$2> = null;
+                if (true
+                    && this.regexAccept(String.raw`(?:\n+)`, "", $$dpth + 1, $$cr) !== null
+                    && ($scope$body = this.matchSTATS_LINE($$dpth + 1, $$cr)) !== null
+                ) {
+                    $$res = {kind: ASTKinds.POKESOL_TEXT_$2, body: $scope$body};
+                }
+                return $$res;
+            });
+    }
+    public matchPOKESOL_TEXT_$3($$dpth: number, $$cr?: ErrorTracker): Nullable<POKESOL_TEXT_$3> {
+        return this.run<POKESOL_TEXT_$3>($$dpth,
+            () => {
+                let $scope$body: Nullable<MOVES_LINE>;
+                let $$res: Nullable<POKESOL_TEXT_$3> = null;
                 if (true
                     && this.regexAccept(String.raw`(?:\n+)`, "", $$dpth + 1, $$cr) !== null
                     && ($scope$body = this.matchMOVES_LINE($$dpth + 1, $$cr)) !== null
                 ) {
-                    $$res = {kind: ASTKinds.POKESOL_TEXT_$2, body: $scope$body};
+                    $$res = {kind: ASTKinds.POKESOL_TEXT_$3, body: $scope$body};
                 }
                 return $$res;
             });
@@ -331,14 +328,14 @@ export class Parser {
     public matchTERATYPE_LINE($$dpth: number, $$cr?: ErrorTracker): Nullable<TERATYPE_LINE> {
         return this.run<TERATYPE_LINE>($$dpth,
             () => {
-                let $scope$teratype: Nullable<Nullable<TERATYPE_VALUE>>;
+                let $scope$teratype: Nullable<TERATYPE_VALUE>;
                 let $$res: Nullable<TERATYPE_LINE> = null;
                 if (true
                     && this.regexAccept(String.raw`(?:テラスタイプ)`, "", $$dpth + 1, $$cr) !== null
                     && this.match_($$dpth + 1, $$cr) !== null
                     && this.regexAccept(String.raw`(?::)`, "", $$dpth + 1, $$cr) !== null
                     && this.match_($$dpth + 1, $$cr) !== null
-                    && (($scope$teratype = this.matchTERATYPE_VALUE($$dpth + 1, $$cr)) || true)
+                    && ($scope$teratype = this.matchTERATYPE_VALUE($$dpth + 1, $$cr)) !== null
                 ) {
                     $$res = {kind: ASTKinds.TERATYPE_LINE, teratype: $scope$teratype};
                 }
@@ -352,6 +349,7 @@ export class Parser {
         return this.run<ABILITY_LINE>($$dpth,
             () => {
                 let $scope$ability: Nullable<Nullable<ABILITY_VALUE>>;
+                let $scope$preMega: Nullable<Nullable<ABILITY_LINE_$0>>;
                 let $$res: Nullable<ABILITY_LINE> = null;
                 if (true
                     && this.regexAccept(String.raw`(?:特性)`, "", $$dpth + 1, $$cr) !== null
@@ -359,8 +357,24 @@ export class Parser {
                     && this.regexAccept(String.raw`(?::)`, "", $$dpth + 1, $$cr) !== null
                     && this.match_($$dpth + 1, $$cr) !== null
                     && (($scope$ability = this.matchABILITY_VALUE($$dpth + 1, $$cr)) || true)
+                    && (($scope$preMega = this.matchABILITY_LINE_$0($$dpth + 1, $$cr)) || true)
                 ) {
-                    $$res = {kind: ASTKinds.ABILITY_LINE, ability: $scope$ability};
+                    $$res = {kind: ASTKinds.ABILITY_LINE, ability: $scope$ability, preMega: $scope$preMega};
+                }
+                return $$res;
+            });
+    }
+    public matchABILITY_LINE_$0($$dpth: number, $$cr?: ErrorTracker): Nullable<ABILITY_LINE_$0> {
+        return this.run<ABILITY_LINE_$0>($$dpth,
+            () => {
+                let $scope$body: Nullable<ABILITY_VALUE>;
+                let $$res: Nullable<ABILITY_LINE_$0> = null;
+                if (true
+                    && this.regexAccept(String.raw`(?:\()`, "", $$dpth + 1, $$cr) !== null
+                    && ($scope$body = this.matchABILITY_VALUE($$dpth + 1, $$cr)) !== null
+                    && this.regexAccept(String.raw`(?:\))`, "", $$dpth + 1, $$cr) !== null
+                ) {
+                    $$res = {kind: ASTKinds.ABILITY_LINE_$0, body: $scope$body};
                 }
                 return $$res;
             });
@@ -374,7 +388,7 @@ export class Parser {
                 let $scope$nature: Nullable<Nullable<NATURE_VALUE>>;
                 let $$res: Nullable<NATURE_LINE> = null;
                 if (true
-                    && this.regexAccept(String.raw`(?:性格)`, "", $$dpth + 1, $$cr) !== null
+                    && this.regexAccept(String.raw`(?:能力補正)`, "", $$dpth + 1, $$cr) !== null
                     && this.match_($$dpth + 1, $$cr) !== null
                     && this.regexAccept(String.raw`(?::)`, "", $$dpth + 1, $$cr) !== null
                     && this.match_($$dpth + 1, $$cr) !== null
@@ -387,24 +401,6 @@ export class Parser {
     }
     public matchNATURE_VALUE($$dpth: number, $$cr?: ErrorTracker): Nullable<NATURE_VALUE> {
         return this.regexAccept(String.raw`(?:[ぁ-ん]+)`, "", $$dpth + 1, $$cr);
-    }
-    public matchSTATS_AND_IV_LINE($$dpth: number, $$cr?: ErrorTracker): Nullable<STATS_AND_IV_LINE> {
-        return this.run<STATS_AND_IV_LINE>($$dpth,
-            () => {
-                let $scope$stats: Nullable<STATS>;
-                let $scope$individuals: Nullable<INDIVIDUALS>;
-                let $$res: Nullable<STATS_AND_IV_LINE> = null;
-                if (true
-                    && ($scope$stats = this.matchSTATS($$dpth + 1, $$cr)) !== null
-                    && this.match_($$dpth + 1, $$cr) !== null
-                    && this.regexAccept(String.raw`(?:\*)`, "", $$dpth + 1, $$cr) !== null
-                    && this.match_($$dpth + 1, $$cr) !== null
-                    && ($scope$individuals = this.matchINDIVIDUALS($$dpth + 1, $$cr)) !== null
-                ) {
-                    $$res = {kind: ASTKinds.STATS_AND_IV_LINE, stats: $scope$stats, individuals: $scope$individuals};
-                }
-                return $$res;
-            });
     }
     public matchSTATS_LINE($$dpth: number, $$cr?: ErrorTracker): Nullable<STATS_LINE> {
         return this.run<STATS_LINE>($$dpth,
@@ -494,9 +490,6 @@ export class Parser {
     }
     public matchEFFORT_VALUE($$dpth: number, $$cr?: ErrorTracker): Nullable<EFFORT_VALUE> {
         return this.regexAccept(String.raw`(?:[1-9][0-9]*)`, "", $$dpth + 1, $$cr);
-    }
-    public matchINDIVIDUALS($$dpth: number, $$cr?: ErrorTracker): Nullable<INDIVIDUALS> {
-        return this.regexAccept(String.raw`(?:[HABCDS0-9, ]+)`, "", $$dpth + 1, $$cr);
     }
     public matchMOVES_LINE($$dpth: number, $$cr?: ErrorTracker): Nullable<MOVES_LINE> {
         return this.choice<MOVES_LINE>([
@@ -772,7 +765,7 @@ class ErrorTracker {
     private mxpos: PosInfo = {overallPos: -1, line: -1, offset: -1};
     private regexset: Set<string> = new Set();
     private pmatches: MatchAttempt[] = [];
-    public record(pos: PosInfo, result: any, att: MatchAttempt): void {
+    public record(pos: PosInfo, result: any, att: MatchAttempt) {
         if ((result === null) === att.negated)
             return;
         if (pos.overallPos > this.mxpos.overallPos) {

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -28,13 +28,42 @@ describe("parse", () => {
   };
 
   test("with full values", () => {
-    const pokesolText = `カイリュー @ あおぞらプレート
+    const pokesolText = `メガガブリアス @ ガブリアスナイト
 テラスタイプ: ステラ
-特性: マルチスケイル
-能力補正: さみしがり
-166-204(32)-132(32)-105-105-101(2)
-じしん / りゅうのまい / テラバースト / けたぐり`;
-    expect(parse(pokesolText)).toEqual(expected);
+特性: すなのちから(さめはだ)
+能力補正: ようき
+193(10)-200(10)-145(10)-135(10)-125(10)-140(16)
+スケイルショット / だいちのちから / がんせきふうじ / ステルスロック`;
+    expect(parse(pokesolText)).toEqual({
+      pokemonName: "メガガブリアス",
+      itemName: "ガブリアスナイト",
+      abilityName: "すなのちから",
+      preMegaAbilityName: "さめはだ",
+      terastalName: "ステラ",
+      natureName: "ようき",
+      evs: {
+        hp: 10,
+        attack: 10,
+        defense: 10,
+        specialAttack: 10,
+        specialDefense: 10,
+        speed: 16,
+      },
+      actualValue: {
+        hp: 193,
+        attack: 200,
+        defense: 145,
+        specialAttack: 135,
+        specialDefense: 125,
+        speed: 140,
+      },
+      moveNames: [
+        "スケイルショット",
+        "だいちのちから",
+        "がんせきふうじ",
+        "ステルスロック",
+      ],
+    });
   });
 
   test("with whitespace", () => {
@@ -112,43 +141,14 @@ describe("parse", () => {
     expect(parse(pokesolText)).toEqual({ ...expected, abilityName: null });
   });
 
-  test("with pre-mega ability", () => {
-    const pokesolText = `メガガブリアス @ ガブリアスナイト
-特性: すなのちから(さめはだ)
-能力補正: ようき
-193(10)-200(10)-145(10)-135(10)-125(10)-140(16)
-スケイルショット / だいちのちから / がんせきふうじ / ステルスロック`;
-    expect(parse(pokesolText)).toEqual({
-      ...expected,
-      pokemonName: "メガガブリアス",
-      itemName: "ガブリアスナイト",
-      abilityName: "すなのちから",
-      preMegaAbilityName: "さめはだ",
-      terastalName: null,
-      natureName: "ようき",
-      evs: {
-        hp: 10,
-        attack: 10,
-        defense: 10,
-        specialAttack: 10,
-        specialDefense: 10,
-        speed: 16,
-      },
-      actualValue: {
-        hp: 193,
-        attack: 200,
-        defense: 145,
-        specialAttack: 135,
-        specialDefense: 125,
-        speed: 140,
-      },
-      moveNames: [
-        "スケイルショット",
-        "だいちのちから",
-        "がんせきふうじ",
-        "ステルスロック",
-      ],
-    });
+  test("without pre-mega ability", () => {
+    const pokesolText = `カイリュー @ あおぞらプレート
+テラスタイプ: ステラ
+特性: マルチスケイル
+能力補正: さみしがり
+166-204(32)-132(32)-105-105-101(2)
+じしん / りゅうのまい / テラバースト / けたぐり`;
+    expect(parse(pokesolText)).toEqual(expected);
   });
 
   test("without nature", () => {

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -5,23 +5,16 @@ describe("parse", () => {
     pokemonName: "カイリュー",
     itemName: "あおぞらプレート",
     abilityName: "マルチスケイル",
+    preMegaAbilityName: null,
     terastalName: "ステラ",
     natureName: "さみしがり",
-    ivs: {
-      hp: 31,
-      attack: 31,
-      defense: 31,
-      specialAttack: 0,
-      specialDefense: 0,
-      speed: 31,
-    },
     evs: {
       hp: 0,
-      attack: 252,
-      defense: 252,
+      attack: 32,
+      defense: 32,
       specialAttack: 0,
       specialDefense: 0,
-      speed: 4,
+      speed: 2,
     },
     actualValue: {
       hp: 166,
@@ -38,8 +31,8 @@ describe("parse", () => {
     const pokesolText = `カイリュー @ あおぞらプレート
 テラスタイプ: ステラ
 特性: マルチスケイル
-性格: さみしがり
-166-204(252)-132(252)-105-105-101(4) *C0,D0
+能力補正: さみしがり
+166-204(32)-132(32)-105-105-101(2)
 じしん / りゅうのまい / テラバースト / けたぐり`;
     expect(parse(pokesolText)).toEqual(expected);
   });
@@ -48,8 +41,8 @@ describe("parse", () => {
     const pokesolText = `カイリュー   @   あおぞらプレート
 テラスタイプ  :   ステラ
 特性  :   マルチスケイル
-性格  :   さみしがり
-166-204(252)-132(252)-105-105-101(4)   *C0  ,  D0
+能力補正  :   さみしがり
+166-204(32)-132(32)-105-105-101(2)
 じしん   /   りゅうのまい   /   テラバースト   /   けたぐり`;
     expect(parse(pokesolText)).toEqual(expected);
   });
@@ -58,8 +51,8 @@ describe("parse", () => {
     const pokesolText = `カイリュー@あおぞらプレート
 テラスタイプ:ステラ
 特性:マルチスケイル
-性格:さみしがり
-166-204(252)-132(252)-105-105-101(4)*C0,D0
+能力補正:さみしがり
+166-204(32)-132(32)-105-105-101(2)
 じしん/りゅうのまい/テラバースト/けたぐり`;
     expect(parse(pokesolText)).toEqual(expected);
   });
@@ -71,9 +64,9 @@ describe("parse", () => {
 
 特性: マルチスケイル
 
-性格: さみしがり
+能力補正: さみしがり
 
-166-204(252)-132(252)-105-105-101(4) *C0,D0
+166-204(32)-132(32)-105-105-101(2)
 
 じしん / りゅうのまい / テラバースト / けたぐり`;
 
@@ -84,18 +77,27 @@ describe("parse", () => {
     const pokesolText = `カイリュー
 テラスタイプ: ステラ
 特性: マルチスケイル
-性格: さみしがり
-166-204(252)-132(252)-105-105-101(4) *C0,D0
+能力補正: さみしがり
+166-204(32)-132(32)-105-105-101(2)
 じしん / りゅうのまい / テラバースト / けたぐり`;
     expect(parse(pokesolText)).toEqual({ ...expected, itemName: null });
   });
 
   test("without teratype", () => {
     const pokesolText = `カイリュー @ あおぞらプレート
-テラスタイプ:
+テラスタイプ: 
 特性: マルチスケイル
-性格: さみしがり
-166-204(252)-132(252)-105-105-101(4) *C0,D0
+能力補正: さみしがり
+166-204(32)-132(32)-105-105-101(2)
+じしん / りゅうのまい / テラバースト / けたぐり`;
+    expect(parse(pokesolText)).toEqual({ ...expected, terastalName: null });
+  });
+
+  test("without teratype line", () => {
+    const pokesolText = `カイリュー @ あおぞらプレート
+特性: マルチスケイル
+能力補正: さみしがり
+166-204(32)-132(32)-105-105-101(2)
 じしん / りゅうのまい / テラバースト / けたぐり`;
     expect(parse(pokesolText)).toEqual({ ...expected, terastalName: null });
   });
@@ -104,18 +106,57 @@ describe("parse", () => {
     const pokesolText = `カイリュー @ あおぞらプレート
 テラスタイプ: ステラ
 特性:
-性格: さみしがり
-166-204(252)-132(252)-105-105-101(4) *C0,D0
+能力補正: さみしがり
+166-204(32)-132(32)-105-105-101(2)
 じしん / りゅうのまい / テラバースト / けたぐり`;
     expect(parse(pokesolText)).toEqual({ ...expected, abilityName: null });
+  });
+
+  test("with pre-mega ability", () => {
+    const pokesolText = `メガガブリアス @ ガブリアスナイト
+特性: すなのちから(さめはだ)
+能力補正: ようき
+193(10)-200(10)-145(10)-135(10)-125(10)-140(16)
+スケイルショット / だいちのちから / がんせきふうじ / ステルスロック`;
+    expect(parse(pokesolText)).toEqual({
+      ...expected,
+      pokemonName: "メガガブリアス",
+      itemName: "ガブリアスナイト",
+      abilityName: "すなのちから",
+      preMegaAbilityName: "さめはだ",
+      terastalName: null,
+      natureName: "ようき",
+      evs: {
+        hp: 10,
+        attack: 10,
+        defense: 10,
+        specialAttack: 10,
+        specialDefense: 10,
+        speed: 16,
+      },
+      actualValue: {
+        hp: 193,
+        attack: 200,
+        defense: 145,
+        specialAttack: 135,
+        specialDefense: 125,
+        speed: 140,
+      },
+      moveNames: [
+        "スケイルショット",
+        "だいちのちから",
+        "がんせきふうじ",
+        "ステルスロック",
+      ],
+    });
   });
 
   test("without nature", () => {
     const pokesolText = `カイリュー @ あおぞらプレート
 テラスタイプ: ステラ
 特性: マルチスケイル
-性格:
-166-204(252)-132(252)-105-105-101(4) *C0,D0
+能力補正:
+166-204(32)-132(32)-105-105-101(2)
 じしん / りゅうのまい / テラバースト / けたぐり`;
     expect(parse(pokesolText)).toEqual({ ...expected, natureName: null });
   });
@@ -124,8 +165,8 @@ describe("parse", () => {
     const pokesolText = `カイリュー @ あおぞらプレート
 テラスタイプ: ステラ
 特性: マルチスケイル
-性格: さみしがり
-166-204-132-105-105-101 *C0,D0
+能力補正: さみしがり
+166-204-132-105-105-101
 じしん / りゅうのまい / テラバースト / けたぐり`;
     expect(parse(pokesolText)).toEqual({
       ...expected,
@@ -140,72 +181,12 @@ describe("parse", () => {
     });
   });
 
-  test("without IV", () => {
-    const pokesolText = `カイリュー @ あおぞらプレート
-テラスタイプ: ステラ
-特性: マルチスケイル
-性格: さみしがり
-166-204(252)-132(252)-105-105-101(4)
-じしん / りゅうのまい / テラバースト / けたぐり`;
-    expect(parse(pokesolText)).toEqual({
-      ...expected,
-      ivs: {
-        hp: 31,
-        attack: 31,
-        defense: 31,
-        specialAttack: 31,
-        specialDefense: 31,
-        speed: 31,
-      },
-    });
-  });
-
-  test("with single IV", () => {
-    const pokesolText = `カイリュー @ あおぞらプレート
-テラスタイプ: ステラ
-特性: マルチスケイル
-性格: さみしがり
-166-204(252)-132(252)-105-105-101(4) *C0
-じしん / りゅうのまい / テラバースト / けたぐり`;
-    expect(parse(pokesolText)).toEqual({
-      ...expected,
-      ivs: {
-        hp: 31,
-        attack: 31,
-        defense: 31,
-        specialAttack: 0,
-        specialDefense: 31,
-        speed: 31,
-      },
-    });
-  });
-
-  test("with arbitrary-ordered IV", () => {
-    const pokesolText = `カイリュー @ あおぞらプレート
-テラスタイプ: ステラ
-特性: マルチスケイル
-性格: さみしがり
-166-204(252)-132(252)-105-105-101(4) *C0,H0
-じしん / りゅうのまい / テラバースト / けたぐり`;
-    expect(parse(pokesolText)).toEqual({
-      ...expected,
-      ivs: {
-        hp: 0,
-        attack: 31,
-        defense: 31,
-        specialAttack: 0,
-        specialDefense: 31,
-        speed: 31,
-      },
-    });
-  });
-
   test("with partial moves", () => {
     const pokesolText = `カイリュー @ あおぞらプレート
 テラスタイプ: ステラ
 特性: マルチスケイル
-性格: さみしがり
-166-204(252)-132(252)-105-105-101(4) *C0,D0
+能力補正: さみしがり
+166-204(32)-132(32)-105-105-101(2)
 じしん`;
     expect(parse(pokesolText)).toEqual({ ...expected, moveNames: ["じしん"] });
   });
@@ -214,18 +195,21 @@ describe("parse", () => {
     const pokesolText = `カイリュー @ あおぞらプレート
 テラスタイプ: ステラ
 特性: マルチスケイル
-性格: さみしがり
-166-204(252)-132(252)-105-105-101(4) *C0,D0
+能力補正: さみしがり
+166-204(32)-132(32)-105-105-101(2)
 ＤＤラリアット`;
-    expect(parse(pokesolText)).toEqual({ ...expected, moveNames: ["ＤＤラリアット"] });
+    expect(parse(pokesolText)).toEqual({
+      ...expected,
+      moveNames: ["ＤＤラリアット"],
+    });
   });
 
   test("with pokemon name with kanji", () => {
     const pokesolText = `バドレックス(黒) @ あおぞらプレート
 テラスタイプ: ステラ
 特性: マルチスケイル
-性格: さみしがり
-166-204(252)-132(252)-105-105-101(4) *C0,D0
+能力補正: さみしがり
+166-204(32)-132(32)-105-105-101(2)
 じしん / りゅうのまい / テラバースト / けたぐり`;
     expect(parse(pokesolText)).toEqual({
       ...expected,
@@ -237,8 +221,8 @@ describe("parse", () => {
     const pokesolText = `パフュートン(♂) @ あおぞらプレート
 テラスタイプ: ステラ
 特性: マルチスケイル
-性格: さみしがり
-166-204(252)-132(252)-105-105-101(4) *C0,D0
+能力補正: さみしがり
+166-204(32)-132(32)-105-105-101(2)
 じしん / りゅうのまい / テラバースト / けたぐり`;
     expect(parse(pokesolText)).toEqual({
       ...expected,
@@ -250,8 +234,8 @@ describe("parse", () => {
     const pokesolText = `カプ・コケコ @ あおぞらプレート
 テラスタイプ: ステラ
 特性: マルチスケイル
-性格: さみしがり
-166-204(252)-132(252)-105-105-101(4) *C0,D0
+能力補正: さみしがり
+166-204(32)-132(32)-105-105-101(2)
 じしん / りゅうのまい / テラバースト / けたぐり`;
     expect(parse(pokesolText)).toEqual({
       ...expected,
@@ -263,8 +247,8 @@ describe("parse", () => {
     const pokesolText = `ジガルデ(50%) @ あおぞらプレート
 テラスタイプ: ステラ
 特性: マルチスケイル
-性格: さみしがり
-166-204(252)-132(252)-105-105-101(4) *C0,D0
+能力補正: さみしがり
+166-204(32)-132(32)-105-105-101(2)
 じしん / りゅうのまい / テラバースト / けたぐり`;
     expect(parse(pokesolText)).toEqual({
       ...expected,
@@ -276,8 +260,8 @@ describe("parse", () => {
     const pokesolText = `ジガルデ(10%) @ あおぞらプレート
 テラスタイプ: ステラ
 特性: マルチスケイル
-性格: さみしがり
-166-204(252)-132(252)-105-105-101(4) *C0,D0
+能力補正: さみしがり
+166-204(32)-132(32)-105-105-101(2)
 じしん / りゅうのまい / テラバースト / けたぐり`;
     expect(parse(pokesolText)).toEqual({
       ...expected,
@@ -289,8 +273,8 @@ describe("parse", () => {
     const pokesolText = `ポリゴン２@ あおぞらプレート
 テラスタイプ: ステラ
 特性: マルチスケイル
-性格: さみしがり
-166-204(252)-132(252)-105-105-101(4) *C0,D0
+能力補正: さみしがり
+166-204(32)-132(32)-105-105-101(2)
 じしん / りゅうのまい / テラバースト / けたぐり`;
     expect(parse(pokesolText)).toEqual({
       ...expected,
@@ -302,8 +286,8 @@ describe("parse", () => {
     const pokesolText = `ミュウツー(メガX) @ あおぞらプレート
 テラスタイプ: ステラ
 特性: マルチスケイル
-性格: さみしがり
-166-204(252)-132(252)-105-105-101(4) *C0,D0
+能力補正: さみしがり
+166-204(32)-132(32)-105-105-101(2)
 じしん / りゅうのまい / テラバースト / けたぐり`;
     expect(parse(pokesolText)).toEqual({
       ...expected,
@@ -315,8 +299,8 @@ describe("parse", () => {
     const pokesolText = `ポリゴンＺ @ あおぞらプレート
 テラスタイプ: ステラ
 特性: マルチスケイル
-性格: さみしがり
-166-204(252)-132(252)-105-105-101(4) *C0,D0
+能力補正: さみしがり
+166-204(32)-132(32)-105-105-101(2)
 じしん / りゅうのまい / テラバースト / けたぐり`;
     expect(parse(pokesolText)).toEqual({
       ...expected,
@@ -324,22 +308,14 @@ describe("parse", () => {
     });
   });
 
-  test("without stats and moves", () => {
+  test("without stats and moves line", () => {
     const pokesolText = `カイリュー
 テラスタイプ: ステラ
 特性: マルチスケイル
-性格: さみしがり`;
+能力補正: さみしがり`;
     expect(parse(pokesolText)).toEqual({
       ...expected,
       itemName: null,
-      ivs: {
-        hp: 31,
-        attack: 31,
-        defense: 31,
-        specialAttack: 31,
-        specialDefense: 31,
-        speed: 31,
-      },
       evs: {
         hp: 0,
         attack: 0,
@@ -360,23 +336,15 @@ describe("parse", () => {
     });
   });
 
-  test("without stats", () => {
+  test("without stats line", () => {
     const pokesolText = `カイリュー
 テラスタイプ: ステラ
 特性: マルチスケイル
-性格: さみしがり
+能力補正: さみしがり
 じしん / りゅうのまい / テラバースト / けたぐり`;
     expect(parse(pokesolText)).toEqual({
       ...expected,
       itemName: null,
-      ivs: {
-        hp: 31,
-        attack: 31,
-        defense: 31,
-        specialAttack: 31,
-        specialDefense: 31,
-        speed: 31,
-      },
       evs: {
         hp: 0,
         attack: 0,
@@ -396,12 +364,12 @@ describe("parse", () => {
     });
   });
 
-  test("without moves", () => {
+  test("without moves line", () => {
     const pokesolText = `カイリュー @ あおぞらプレート
 テラスタイプ: ステラ
 特性: マルチスケイル
-性格: さみしがり
-166-204(252)-132(252)-105-105-101(4) *C0,D0`;
+能力補正: さみしがり
+166-204(32)-132(32)-105-105-101(2)`;
     expect(parse(pokesolText)).toEqual({ ...expected, moveNames: [] });
   });
 
@@ -411,9 +379,9 @@ describe("parse", () => {
 カイリュー @ あおぞらプレート // comment
 テラスタイプ: ステラ          // comment
 特性: マルチスケイル          // comment
-性格: さみしがり              // comment
+能力補正: さみしがり          // comment
 // comment
-166-204(252)-132(252)-105-105-101(4) *C0,D0    // comment
+166-204(32)-132(32)-105-105-101(2)    // comment
 じしん / りゅうのまい / テラバースト / けたぐり// comment
 // comment
 `;


### PR DESCRIPTION
ポケモン champions 仕様のフォーマットに対応
- テラスタイプ行を省略可能に変更
- メガシンカ前特性(preMegaAbilityName)フィールドを追加
- 「性格」ラベルを「能力補正」に変更
- 個体値(ivs)パース機能を削除