### PR TITLE
refactor: replace abilityName/preMegaAbilityName with abilityNames array

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,8 +23,7 @@ console.dir(parse(pokesolText), { depth: null })
 {
   pokemonName: 'メガガブリアス',
   itemName: 'ガブリアスナイト',
-  abilityName: 'すなのちから',
-  preMegaAbilityName: 'さめはだ',
+  abilityNames: [ 'すなのちから', 'さめはだ' ],
   terastalName: null,
   natureName: 'ようき',
   evs: {

--- a/src/grammar.peg
+++ b/src/grammar.peg
@@ -23,7 +23,7 @@ TERATYPE_VALUE := '[ぁ-んァ-ヶー]*'
 
 // 3 行目
 
-ABILITY_LINE  := '特性' _ ':' _ ability=ABILITY_VALUE? _ preMega={ '\(' body=ABILITY_VALUE '\)' }?
+ABILITY_LINE  := '特性' _ ':' _ ability=ABILITY_VALUE? _ preEvolution={ '\(' body=ABILITY_VALUE '\)' }?
 ABILITY_VALUE := '[ぁ-んァ-ヶー]+'
 
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -12,8 +12,7 @@ type ActualValue = {
 export type PokesolTextParseReult = {
   pokemonName: string | null;
   itemName: string | null;
-  abilityName: string | null;
-  preMegaAbilityName: string | null;
+  abilityNames: string[];
   terastalName: string | null;
   natureName: string | null;
   evs: {
@@ -44,8 +43,10 @@ export const parse = (pokesolText: string): PokesolTextParseReult => {
       : null;
 
   const terastalName = result.ast.line2?.body.teratype || null;
-  const abilityName = result.ast.line3.ability || null;
-  const preMegaAbilityName = result.ast.line3.preMega?.body || null;
+  const abilityNames = [
+    result.ast.line3.ability,
+    result.ast.line3.preEvolution?.body,
+  ].filter((v): v is string => v != null);
   const natureName = result.ast.line4.nature || null;
 
   const evs = {
@@ -120,8 +121,7 @@ export const parse = (pokesolText: string): PokesolTextParseReult => {
   return {
     pokemonName,
     itemName,
-    abilityName,
-    preMegaAbilityName,
+    abilityNames,
     terastalName,
     natureName,
     evs,

--- a/src/parser.ts
+++ b/src/parser.ts
@@ -16,7 +16,7 @@
 * TERATYPE_LINE  := 'テラスタイプ' _ ':' _ teratype=TERATYPE_VALUE
 * TERATYPE_VALUE := '[ぁ-んァ-ヶー]*'
 * // 3 行目
-* ABILITY_LINE  := '特性' _ ':' _ ability=ABILITY_VALUE? _ preMega={ '\(' body=ABILITY_VALUE '\)' }?
+* ABILITY_LINE  := '特性' _ ':' _ ability=ABILITY_VALUE? _ preEvolution={ '\(' body=ABILITY_VALUE '\)' }?
 * ABILITY_VALUE := '[ぁ-んァ-ヶー]+'
 * // 4 行目
 * NATURE_LINE  := '能力補正' _ ':' _ nature=NATURE_VALUE?
@@ -124,7 +124,7 @@ export type TERATYPE_VALUE = string;
 export interface ABILITY_LINE {
     kind: ASTKinds.ABILITY_LINE;
     ability: Nullable<ABILITY_VALUE>;
-    preMega: Nullable<ABILITY_LINE_$0>;
+    preEvolution: Nullable<ABILITY_LINE_$0>;
 }
 export interface ABILITY_LINE_$0 {
     kind: ASTKinds.ABILITY_LINE_$0;
@@ -349,7 +349,7 @@ export class Parser {
         return this.run<ABILITY_LINE>($$dpth,
             () => {
                 let $scope$ability: Nullable<Nullable<ABILITY_VALUE>>;
-                let $scope$preMega: Nullable<Nullable<ABILITY_LINE_$0>>;
+                let $scope$preEvolution: Nullable<Nullable<ABILITY_LINE_$0>>;
                 let $$res: Nullable<ABILITY_LINE> = null;
                 if (true
                     && this.regexAccept(String.raw`(?:特性)`, "", $$dpth + 1, $$cr) !== null
@@ -358,9 +358,9 @@ export class Parser {
                     && this.match_($$dpth + 1, $$cr) !== null
                     && (($scope$ability = this.matchABILITY_VALUE($$dpth + 1, $$cr)) || true)
                     && this.match_($$dpth + 1, $$cr) !== null
-                    && (($scope$preMega = this.matchABILITY_LINE_$0($$dpth + 1, $$cr)) || true)
+                    && (($scope$preEvolution = this.matchABILITY_LINE_$0($$dpth + 1, $$cr)) || true)
                 ) {
-                    $$res = {kind: ASTKinds.ABILITY_LINE, ability: $scope$ability, preMega: $scope$preMega};
+                    $$res = {kind: ASTKinds.ABILITY_LINE, ability: $scope$ability, preEvolution: $scope$preEvolution};
                 }
                 return $$res;
             });

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -4,8 +4,7 @@ describe("parse", () => {
   const expected = {
     pokemonName: "メガガブリアス",
     itemName: "ガブリアスナイト",
-    abilityName: "すなのちから",
-    preMegaAbilityName: "さめはだ",
+    abilityNames: ["すなのちから", "さめはだ"],
     terastalName: "ステラ",
     natureName: "ようき",
     evs: {
@@ -109,17 +108,17 @@ describe("parse", () => {
 能力補正: ようき
 193(10)-200(10)-145(10)-135(10)-125(10)-140(16)
 スケイルショット / だいちのちから / がんせきふうじ / ステルスロック`;
-    expect(parse(pokesolText)).toEqual({ ...expected, abilityName: null, preMegaAbilityName: null });
+    expect(parse(pokesolText)).toEqual({ ...expected, abilityNames: [] });
   });
 
-  test("without pre-mega ability", () => {
+  test("without pre-evolution ability", () => {
     const pokesolText = `メガガブリアス @ ガブリアスナイト
 テラスタイプ: ステラ
-特性: すなのちから(さめはだ)
+特性: すなのちから
 能力補正: ようき
 193(10)-200(10)-145(10)-135(10)-125(10)-140(16)
 スケイルショット / だいちのちから / がんせきふうじ / ステルスロック`;
-    expect(parse(pokesolText)).toEqual(expected);
+    expect(parse(pokesolText)).toEqual({ ...expected, abilityNames: ["すなのちから"] });
   });
 
   test("without nature", () => {


### PR DESCRIPTION
## Summary
- `abilityName` / `preMegaAbilityName` を `abilityNames: string[]` に統合
- 文法/パーサー内部の `preMega` を `preEvolution` にリネーム

## Motivation
旧インターフェースはメガ進化を前提としたフィールド名になっており、
特定の進化形態にしか対応できない構造だった。
将来 N 種類の形態変化が追加されても破綻しないよう、
形態に依存しない汎用的な配列表現に変更する。

## Breaking Changes
- `abilityName: string | null` → 削除
- `preMegaAbilityName: string | null` → 削除
- `abilityNames: string[]` → 新設（要素順: [現在の特性, 進化前の特性]）
