### PR TITLE
fix: allow fullwidth alpha characters (ＸＹＺ) in ITEM_VALUE pattern

### DIFF
--- a/src/grammar.peg
+++ b/src/grammar.peg
@@ -12,7 +12,7 @@ POKESOL_TEXT :=
 POKEMON_AND_ITEM_LINE := pokemon=POKEMON_VALUE _ '@' _ item=ITEM_VALUE
 POKEMON_LINE          := pokemon=POKEMON_VALUE
 POKEMON_VALUE         := '[0-9０-９a-zA-ZＡ-Ｚぁ-んァ-ヶー一-龠・()♂♀%]+'
-ITEM_VALUE            := '[ぁ-んァ-ヶー]+'
+ITEM_VALUE            := '[ぁ-んァ-ヶーＸＹＺ]+'
 
 
 // 2 行目

--- a/src/grammar.peg
+++ b/src/grammar.peg
@@ -12,7 +12,7 @@ POKESOL_TEXT :=
 POKEMON_AND_ITEM_LINE := pokemon=POKEMON_VALUE _ '@' _ item=ITEM_VALUE
 POKEMON_LINE          := pokemon=POKEMON_VALUE
 POKEMON_VALUE         := '[0-9０-９a-zA-ZＡ-Ｚぁ-んァ-ヶー一-龠・()♂♀%]+'
-ITEM_VALUE            := '[ぁ-んァ-ヶーＸＹＺ]+'
+ITEM_VALUE            := '[ぁ-んァ-ヶーＸＹＺXYZ]+'
 
 
 // 2 行目

--- a/src/parser.ts
+++ b/src/parser.ts
@@ -11,7 +11,7 @@
 * POKEMON_AND_ITEM_LINE := pokemon=POKEMON_VALUE _ '@' _ item=ITEM_VALUE
 * POKEMON_LINE          := pokemon=POKEMON_VALUE
 * POKEMON_VALUE         := '[0-9０-９a-zA-ZＡ-Ｚぁ-んァ-ヶー一-龠・()♂♀%]+'
-* ITEM_VALUE            := '[ぁ-んァ-ヶーＸＹＺ]+'
+* ITEM_VALUE            := '[ぁ-んァ-ヶーＸＹＺXYZ]+'
 * // 2 行目
 * TERATYPE_LINE  := 'テラスタイプ' _ ':' _ teratype=TERATYPE_VALUE
 * TERATYPE_VALUE := '[ぁ-んァ-ヶー]*'
@@ -323,7 +323,7 @@ export class Parser {
         return this.regexAccept(String.raw`(?:[0-9０-９a-zA-ZＡ-Ｚぁ-んァ-ヶー一-龠・()♂♀%]+)`, "", $$dpth + 1, $$cr);
     }
     public matchITEM_VALUE($$dpth: number, $$cr?: ErrorTracker): Nullable<ITEM_VALUE> {
-        return this.regexAccept(String.raw`(?:[ぁ-んァ-ヶーＸＹＺ]+)`, "", $$dpth + 1, $$cr);
+        return this.regexAccept(String.raw`(?:[ぁ-んァ-ヶーＸＹＺXYZ]+)`, "", $$dpth + 1, $$cr);
     }
     public matchTERATYPE_LINE($$dpth: number, $$cr?: ErrorTracker): Nullable<TERATYPE_LINE> {
         return this.run<TERATYPE_LINE>($$dpth,

--- a/src/parser.ts
+++ b/src/parser.ts
@@ -11,7 +11,7 @@
 * POKEMON_AND_ITEM_LINE := pokemon=POKEMON_VALUE _ '@' _ item=ITEM_VALUE
 * POKEMON_LINE          := pokemon=POKEMON_VALUE
 * POKEMON_VALUE         := '[0-9０-９a-zA-ZＡ-Ｚぁ-んァ-ヶー一-龠・()♂♀%]+'
-* ITEM_VALUE            := '[ぁ-んァ-ヶー]+'
+* ITEM_VALUE            := '[ぁ-んァ-ヶーＸＹＺ]+'
 * // 2 行目
 * TERATYPE_LINE  := 'テラスタイプ' _ ':' _ teratype=TERATYPE_VALUE
 * TERATYPE_VALUE := '[ぁ-んァ-ヶー]*'
@@ -323,7 +323,7 @@ export class Parser {
         return this.regexAccept(String.raw`(?:[0-9０-９a-zA-ZＡ-Ｚぁ-んァ-ヶー一-龠・()♂♀%]+)`, "", $$dpth + 1, $$cr);
     }
     public matchITEM_VALUE($$dpth: number, $$cr?: ErrorTracker): Nullable<ITEM_VALUE> {
-        return this.regexAccept(String.raw`(?:[ぁ-んァ-ヶー]+)`, "", $$dpth + 1, $$cr);
+        return this.regexAccept(String.raw`(?:[ぁ-んァ-ヶーＸＹＺ]+)`, "", $$dpth + 1, $$cr);
     }
     public matchTERATYPE_LINE($$dpth: number, $$cr?: ErrorTracker): Nullable<TERATYPE_LINE> {
         return this.run<TERATYPE_LINE>($$dpth,


### PR DESCRIPTION
- もちものにアルファベットXYZを含むパターンがある(例：リザードナイトY)ので、パーサーの許容範囲を広げました
- ~半角と全角迷ったのですが、わざが全角英字だけ許容していたので合わせました~